### PR TITLE
Reproduction fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ fr.inria.main.evolution.MainIFPar
 
 The option -help shows the usage of them.
 
-Additionally, the distribution contains a version of Apache commons Math with a real defect (reported in issue 280 https://issues.apache.org/jira/browse/MATH-280).
-To run it using GenProg, type: java fr.inria.main.evolution.MainIFGenProg -bug280
-
 
 
 B) jGenProg:
 We provide an implementation of GenProg repair algorithm.
 The class to run it is:
 fr.inria.main.evolution.MainjGenProg
+
+Additionally, the distribution contains a version of Apache commons Math with a real defect (reported in issue 280 https://issues.apache.org/jira/browse/MATH-280).
+To run it using GenProg, type: java fr.inria.main.evolution.MainjGenProg -bug280
 
 This implementations applies the GenProg's operators over 1) statements in a code block, 2) conditions in if and boucle.
 After the execution, Astor writes in the output folder (property 'workingDirectory'in the mentioned file), a folder with all the variants that fulfill the goals i.e., repair the bugs.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Getting started
 To compile using maven:
 mvn install
 
-See configuration file "configuration.properties" for configuring, for instance, the output folder location or jvm dir.
+Note that this project requires the use of Java 1.7; it does not build (on OS X 10.10.3) with Java 1.8.
+
+See configuration file "configuration.properties" for configuring, for instance, the output folder location or jvm dir.  This is a required step; look for jvm4testexecution and be sure it is accurate for your environment.
 
 **Evolutionary**
 
@@ -36,7 +38,7 @@ The option -help shows the usage of them.
 Additionally, the distribution contains a version of Apache commons Math with a real defect (reported in issue 280 https://issues.apache.org/jira/browse/MATH-280).
 To run it using GenProg, type: java fr.inria.main.evolution.MainIFGenProg -bug280
 
-Use Java 1.7
+
 
 B) jGenProg:
 We provide an implementation of GenProg repair algorithm.

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
 			<id>inria</id>
 			<url>http://spoon.gforge.inria.fr/repositories/releases/</url>
 		</repository>
+	<repository>
+		<id>gforge.inria.fr-snapshot</id>
+		<name>Maven Repository for Spoon Snapshot</name>
+		<url>http://spoon.gforge.inria.fr/repositories/snapshots/</url>
+		<snapshots />
+	</repository>
 	</repositories>
 
 	<build>

--- a/src/main/java/fr/inria/main/AbstractMain.java
+++ b/src/main/java/fr/inria/main/AbstractMain.java
@@ -310,7 +310,8 @@ public abstract class AbstractMain {
 			String folder = "Math-issue-280";
 			String failing = "org.apache.commons.math.distribution.NormalDistributionTest";
 			File f = new File("examples/Math-issue-280/");
-			String location = f.getParent();
+            //			String location = f.getParent();
+            String location = "examples/Math-issue-280/";
 			String packageToInstrument = "org.apache.commons";
 			double thfl = 0.5;
 			this.run(location, folder, dependenciespath, packageToInstrument, thfl, failing);

--- a/src/main/java/fr/inria/main/evolution/MainjGenProg.java
+++ b/src/main/java/fr/inria/main/evolution/MainjGenProg.java
@@ -151,6 +151,9 @@ public class MainjGenProg extends AbstractMain {
 	public static void main(String[] args) throws Exception {
 		System.out.println("Arguments: "+ Arrays.toString(args).replace(",", " "));
 		MainjGenProg m = new MainjGenProg();
+		boolean isExample = m.executeExample(args);
+		if (isExample)
+			return;
 		
 		boolean correct = m.processArguments(args);
 		if(!correct){
@@ -158,9 +161,6 @@ public class MainjGenProg extends AbstractMain {
 			return;
 		}
 		
-		/*boolean isExample = m.executeExample(args);
-		if (isExample)
-			return;*/
 
 		String dependencies = ConfigurationProperties.getProperty("dependenciespath");
 		String failing = ConfigurationProperties.getProperty("failing");

--- a/src/main/resources/configuration.properties
+++ b/src/main/resources/configuration.properties
@@ -5,7 +5,9 @@ mode=statement
 #Dir for the output from Mutation and evolution
 workingDirectory=./outputMutation/
 #Virtual Machine Parameters (bin folder example /home/user/jdk1.7.0_51/bin/)
-jvm4testexecution=/home/matias/develop/jdk1.8.0_31/bin/
+#jvm4testexecution=/home/matias/develop/jdk1.8.0_31/bin/
+# FIXME: change this for your environment!
+jvm4testexecution=/Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home/bin/
 #Java compliance Level
 javacompliancelevel=7
 alternativecompliancelevel=4


### PR DESCRIPTION
Hello, friends at Lille!

I've been playing with Astor a bit.  I've made a few changes to enable the execution of bug280, per your documentation.  Some of these changes relate strictly to documentation, but a couple of code and pom.xml fixes were in order as well.  

As I'm only minimally familiar with the codebase so far, I made the smallest changes I could to get bug280 to execute. However, I think that a larger conceptual fix is necessary in command-line argument processing to enable the execution of the hard-coded bug examples across the different Main*GenProg programs.  In particular, mProcessArguments in AbstractMain does not special-handle the bug examples.  Without my edits, passing -bug280 to MainjGenProg led to a usage message because the required arguments for a generic repair effort are omitted.  I uncommented the isExample check and moved it above the command line argument processing.  However, this does not address the general problem e.g., in MainIFjGenProg, which did not have such special example handling (commented out or otherwise).

I should probably put all that in an issue and not this comment, but I wanted to let you know what I'm up to so that the pull request made sense.

Cheers,
-Claire