### PR TITLE
Random seed feature

### DIFF
--- a/src/main/java/fr/inria/astor/core/loop/evolutionary/EvolutionaryEngine.java
+++ b/src/main/java/fr/inria/astor/core/loop/evolutionary/EvolutionaryEngine.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 import org.apache.commons.collections.map.HashedMap;
 import org.apache.log4j.Logger;
@@ -30,6 +29,7 @@ import fr.inria.astor.core.loop.evolutionary.spaces.operators.RepairOperatorSpac
 import fr.inria.astor.core.manipulation.MutationSupporter;
 import fr.inria.astor.core.manipulation.bytecode.entities.CompilationResult;
 import fr.inria.astor.core.setup.ConfigurationProperties;
+import fr.inria.astor.core.setup.RandomManager;
 import fr.inria.astor.core.setup.ProjectRepairFacade;
 import fr.inria.astor.core.stats.StatPatch;
 import fr.inria.astor.core.stats.Stats;
@@ -442,17 +442,6 @@ public abstract class EvolutionaryEngine {
 			undoOperationToSpoonElement(genOperation);
 		}
 	}
-
-	/**
-	 * For each gen of the variant, create a mutation. These are stored in the
-	 * program variant.
-	 * 
-	 * @param variant
-	 * @param generation
-	 * @return if at least one gen mutation is created
-	 * @throws Exception
-	 */
-	Random random = new Random();
 
 	/**
 	 * Given a program variant, the method generates operations for modifying

--- a/src/main/java/fr/inria/astor/core/loop/evolutionary/JGenProgIfExpression.java
+++ b/src/main/java/fr/inria/astor/core/loop/evolutionary/JGenProgIfExpression.java
@@ -1,7 +1,6 @@
 package fr.inria.astor.core.loop.evolutionary;
 
 import java.util.List;
-import java.util.Random;
 
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtExpression;
@@ -17,6 +16,7 @@ import fr.inria.astor.core.entities.taxonomy.GenProgMutationOperation;
 import fr.inria.astor.core.manipulation.MutationSupporter;
 import fr.inria.astor.core.manipulation.sourcecode.ExpressionRevolver;
 import fr.inria.astor.core.setup.ProjectRepairFacade;
+import fr.inria.astor.core.setup.RandomManager;
 
 /**
  * Extension of Evolutionary loop with GenProgOperations to manage IfConditions
@@ -26,8 +26,6 @@ import fr.inria.astor.core.setup.ProjectRepairFacade;
  */
 public class JGenProgIfExpression extends JGenProg {
 
-	
-	Random random = new Random();
 	
 	public JGenProgIfExpression(MutationSupporter mutatorExecutor, ProjectRepairFacade projFacade)
 			throws JSAPException {
@@ -90,7 +88,7 @@ public class JGenProgIfExpression extends JGenProg {
 		if(ctExp == null || ctExp.isEmpty())
 			return fullIfCondition;
 		
-		int index = random.nextInt(ctExp.size());		
+		int index = RandomManager.nextInt(ctExp.size());		
 		return ctExp.get(index);
 	}
 

--- a/src/main/java/fr/inria/astor/core/loop/evolutionary/MutationalRepair.java
+++ b/src/main/java/fr/inria/astor/core/loop/evolutionary/MutationalRepair.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtIf;
@@ -24,6 +23,8 @@ import fr.inria.astor.core.loop.mutation.mutants.operators.RelationalBinaryOpera
 import fr.inria.astor.core.manipulation.MutationSupporter;
 import fr.inria.astor.core.setup.ProjectRepairFacade;
 import fr.inria.astor.core.stats.StatSpaceSize;
+
+import fr.inria.astor.core.setup.RandomManager;
 
 /**
  * Mutational evolution.
@@ -121,7 +122,7 @@ public class MutationalRepair extends JGenProg {
 	}
 
 	protected CtElement uniformRandom(List<MutantCtElement> mutations) {
-		return mutations.get((new Random()).nextInt(mutations.size())).getElement();
+		return mutations.get(RandomManager.nextInt(mutations.size())).getElement();
 	}
 	/**
 	 * 

--- a/src/main/java/fr/inria/astor/core/loop/evolutionary/ParRepair.java
+++ b/src/main/java/fr/inria/astor/core/loop/evolutionary/ParRepair.java
@@ -1,7 +1,6 @@
 package fr.inria.astor.core.loop.evolutionary;
 
 import java.util.List;
-import java.util.Random;
 
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
@@ -20,6 +19,7 @@ import fr.inria.astor.core.entities.ProgramVariant;
 import fr.inria.astor.core.entities.taxonomy.ParMutationOperation;
 import fr.inria.astor.core.manipulation.MutationSupporter;
 import fr.inria.astor.core.setup.ProjectRepairFacade;
+import fr.inria.astor.core.setup.RandomManager;
 
 /**
  * Extension of Evolutionary loop with GenProgOperations to manage IfConditions
@@ -170,8 +170,7 @@ public class ParRepair extends JGenProg {
 	 * @return
 	 */
 	private BinaryOperatorKind getBinaryOperator() {
-		Random r = new Random();
-		double d = r.nextDouble();
+		double d = RandomManager.nextDouble();
 		if (d > 0.5d)
 			return BinaryOperatorKind.AND;
 		else

--- a/src/main/java/fr/inria/astor/core/loop/evolutionary/spaces/implementation/UniformRandomRepairOperatorSpace.java
+++ b/src/main/java/fr/inria/astor/core/loop/evolutionary/spaces/implementation/UniformRandomRepairOperatorSpace.java
@@ -1,12 +1,10 @@
 package fr.inria.astor.core.loop.evolutionary.spaces.implementation;
 
-import java.util.Random;
-
 import fr.inria.astor.core.entities.taxonomy.GenProgMutationOperation;
 import fr.inria.astor.core.entities.taxonomy.MutationOperation;
 import fr.inria.astor.core.loop.evolutionary.spaces.operators.RepairOperatorSpace;
 import fr.inria.astor.core.setup.ConfigurationProperties;
-
+import fr.inria.astor.core.setup.RandomManager;
 /**
  * Represents a Uniform Random Repair operator space.
  * @author Matias Martinez,  matias.martinez@inria.fr
@@ -14,16 +12,14 @@ import fr.inria.astor.core.setup.ConfigurationProperties;
  */
 public class UniformRandomRepairOperatorSpace implements RepairOperatorSpace {
 
-	private Random random = new Random();
-		
 	@Override
 	public MutationOperation getNextMutation() {
-		 return values()[random.nextInt(values().length)];
+		 return values()[RandomManager.nextInt(values().length)];
 	}
 
 	@Override
 	public MutationOperation getNextMutation(double suspiciousValue) {
-		double randomVal = random.nextDouble();
+		double randomVal = RandomManager.nextDouble();
 		if(	!ConfigurationProperties.getPropertyBool("probagenmutation") || ( suspiciousValue * ConfigurationProperties.getPropertyDouble("mutationrate") ) >= randomVal ){
 			return this.getNextMutation();
 		}

--- a/src/main/java/fr/inria/astor/core/loop/evolutionary/spaces/implementation/spoon/WeightCtElement.java
+++ b/src/main/java/fr/inria/astor/core/loop/evolutionary/spaces/implementation/spoon/WeightCtElement.java
@@ -3,9 +3,10 @@ package fr.inria.astor.core.loop.evolutionary.spaces.implementation.spoon;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Random;
 
 import org.apache.log4j.Logger;
+
+import fr.inria.astor.core.setup.RandomManager;
 
 public class WeightCtElement {
 
@@ -50,8 +51,7 @@ public class WeightCtElement {
 
 	public static WeightCtElement selectElementWeightBalanced(List<WeightCtElement> we) {
 		WeightCtElement selected = null;
-		Random r = new Random();
-		double d = r.nextDouble();
+		double d = RandomManager.nextDouble();
 		
 		for (int i = 0; (selected == null && i < we.size()); i++) {
 			if (d <= we.get(i).accum) {

--- a/src/main/java/fr/inria/astor/core/loop/evolutionary/spaces/ingredients/UniformRandomFixSpace.java
+++ b/src/main/java/fr/inria/astor/core/loop/evolutionary/spaces/ingredients/UniformRandomFixSpace.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 import org.apache.log4j.Logger;
 
@@ -15,6 +14,8 @@ import com.martiansoftware.jsap.JSAPException;
 
 import fr.inria.astor.core.loop.evolutionary.spaces.implementation.spoon.processor.AbstractFixSpaceProcessor;
 import fr.inria.astor.core.manipulation.MutationSupporter;
+
+import fr.inria.astor.core.setup.RandomManager;
 
 /**
  * This Fix Space takes uniform randomly elements from the the search space.
@@ -41,8 +42,6 @@ public abstract class UniformRandomFixSpace<L extends Object, I extends CtCodeEl
 	
 	
 	private  IngredientProcessor<L, I> ingredientProcessor;
-	
-	private Random random = new Random();
 	
 	public UniformRandomFixSpace() throws JSAPException {
 		super();
@@ -137,7 +136,7 @@ public abstract class UniformRandomFixSpace<L extends Object, I extends CtCodeEl
 	 */
 	protected I getRandomStatementFromSpace(List<I> fixSpace) {
 		int size = fixSpace.size();
-		int index = random.nextInt(size);
+		int index = RandomManager.nextInt(size);
 		return fixSpace.get(index);
 
 	}

--- a/src/main/java/fr/inria/astor/core/loop/evolutionary/transformators/CtExpressionTransformator.java
+++ b/src/main/java/fr/inria/astor/core/loop/evolutionary/transformators/CtExpressionTransformator.java
@@ -1,7 +1,5 @@
 package fr.inria.astor.core.loop.evolutionary.transformators;
 
-import java.util.Random;
-
 import org.apache.log4j.Logger;
 
 import spoon.reflect.code.BinaryOperatorKind;
@@ -12,6 +10,9 @@ import spoon.reflect.factory.FactoryImpl;
 import fr.inria.astor.core.entities.GenOperationInstance;
 import fr.inria.astor.core.entities.taxonomy.ParMutationOperation;
 import fr.inria.astor.core.manipulation.MutationSupporter;
+
+import fr.inria.astor.core.setup.RandomManager;
+
 /**
  * 
  * @author Matias Martinez
@@ -105,8 +106,7 @@ public class CtExpressionTransformator implements ModelTransformator{
 	}
 	
 	private BinaryOperatorKind getBinaryOperator() {
-		Random r = new Random();
-		double d = r.nextDouble();
+		double d = RandomManager.nextDouble();
 		if (d > 0.5d)
 			return BinaryOperatorKind.AND;
 		else

--- a/src/main/java/fr/inria/astor/core/setup/ConfigurationProperties.java
+++ b/src/main/java/fr/inria/astor/core/setup/ConfigurationProperties.java
@@ -29,6 +29,13 @@ public class ConfigurationProperties {
 
 	}
 	
+    public static boolean hasProperty(String key) {
+        if(properties.getProperty(key) == null) {
+            return false;
+        } 
+        return true;
+    }
+
 	public static String getProperty(String key){
 		return properties.getProperty(key);
 	}

--- a/src/main/java/fr/inria/astor/core/setup/RandomManager.java
+++ b/src/main/java/fr/inria/astor/core/setup/RandomManager.java
@@ -1,0 +1,45 @@
+package fr.inria.astor.core.setup;
+
+import java.util.Random;
+import fr.inria.astor.core.setup.ConfigurationProperties;
+
+/**
+ * 
+ * @author Claire Le Goues (CLG), clegoues@cs.cmu.edu
+ * 
+ * RandomManager is a static provider of randomness to all interested classes.
+ * This allows the experiment to specify a random seed at configuration time
+ * that can then be used to reproduce particular runs.
+ * 
+ * Note that this feels a bit heavyweight to CLG, as she was trying to just
+ * replace the calls to new Random() in place, but that solution appeared a bit
+ * scattered.
+ * 
+ * If accepted as a solution to the reproducible randomness problem, the project
+ * moving forward should stringently disallow calls to new java.util.Random, and
+ * all randomness requirements should be mediated through this class.
+ * 
+ */
+public class RandomManager {
+
+    private static Random randomNumberGenerator = null;
+
+    public static void initialize() {
+        if(ConfigurationProperties.hasProperty("seed")) {
+            Integer seed = ConfigurationProperties.getPropertyInt("seed");
+            randomNumberGenerator = new Random(seed);
+        } else {
+            // CLG would love a way to be able to print the seed used here, but
+            // Java.Random does not seem to provide such functionality.  
+            randomNumberGenerator = new Random();
+        }
+    }
+
+    public static Integer nextInt(int bound) {
+        return randomNumberGenerator.nextInt(bound);
+    }
+    public static Double nextDouble() {
+        return randomNumberGenerator.nextDouble();
+    }
+    
+}

--- a/src/main/java/fr/inria/main/AbstractMain.java
+++ b/src/main/java/fr/inria/main/AbstractMain.java
@@ -21,6 +21,8 @@ import fr.inria.astor.core.setup.ConfigurationProperties;
 import fr.inria.astor.core.setup.ProjectConfiguration;
 import fr.inria.astor.core.setup.ProjectRepairFacade;
 
+import fr.inria.astor.core.setup.RandomManager;
+
 /**
  * 
  * @author Matias Martinez
@@ -133,6 +135,9 @@ public abstract class AbstractMain {
 	
 		options.addOption("alternativecompliancelevel", true,
 				"(Optional) Alternative compliance level. Default Java 1.4. Used after Astor tries to compile to the complicance level and fails.");
+
+		options.addOption("seed", true,
+                          "(Optional) Random seed, for reproducible runs.  Default is whatever java.util.Random uses when not explicitly initialized.");
 	
 
 	}
@@ -289,8 +294,9 @@ public abstract class AbstractMain {
 		if (cmd.hasOption("uniqueoptogen"))
 			ConfigurationProperties.properties.setProperty("uniqueoptogen", cmd.getOptionValue("uniqueoptogen"));
 		
-		
-		
+        // CLG believes, but is not totally confident in her belief, that this
+        // is a reasonable place to initialize the random number generator.		
+		RandomManager.initialize();
 		return true;
 	}
 


### PR DESCRIPTION
I think I did this properly; git is confusing.  My goal was to issue two pull requests: one for the feature that allows command line options to be parsed when running example bugs, the other to change the way randomness is handled to allow the user to pass a seed for easy run reproduction.  This is the latter feature.

I added a class in the core setup package called RandomManager that is intended to be used statically.  It is initialized after the command line arguments are parsed, since that is when the seed may be read.  If a seed is provided, that seed is used in the initializing call to Random(); otherwise, new Random() is called, without an argument. The random generator is stored privately by the manager.  The idea is then that *any* call for a new random number (nextInt, nextDouble, etc) should be mediated by RandomManager.  I deleted all internal inclusions of java.util.Random, just to make that point.

Execution without a seed should give roughly the same behavior as before, though now there's just one random number generator (there were several new Random objects created throughout the codebase before).  Execution with a seed should lead to the same reproducible run every time. 