### PR TITLE
Specify a parent to the URLClassLoader

### DIFF
--- a/src/main/java/fr/inria/astor/core/faultlocalization/entity/TestClassesFinder.java
+++ b/src/main/java/fr/inria/astor/core/faultlocalization/entity/TestClassesFinder.java
@@ -91,7 +91,7 @@ public final class TestClassesFinder implements Callable<Collection<Class<?>>> {
 	}
 
 	public String[] findIn(final URL[] classpath, boolean acceptTestSuite) {
-		return findIn(new URLClassLoader(classpath), acceptTestSuite);
+		return findIn(new URLClassLoader(classpath, Thread.currentThread().getContextClassLoader()), acceptTestSuite);
 	}
 
 	public String[] removeTestSuite(String[] totalTest) {


### PR DESCRIPTION
Fix an issue when astor is run in a maven plugin