### PR TITLE
Upgrade to Spoon 6.2.0 and fix OutputWritter to avoid NPE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>fr.inria.gforge.spoon</groupId>
 			<artifactId>spoon-core</artifactId>
-			<version>6.0.0</version>
+			<version>6.2.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId></groupId>

--- a/src/main/java/fr/inria/astor/core/manipulation/bytecode/OutputWritter.java
+++ b/src/main/java/fr/inria/astor/core/manipulation/bytecode/OutputWritter.java
@@ -36,10 +36,11 @@ public class OutputWritter {
 	}
 
 	public void updateOutput(String output) {
-		JavaOutputProcessor fileOutput = new JavaOutputProcessor(new File(output),
-				new DefaultJavaPrettyPrinter(getEnvironment()));
-		this.javaPrinter = fileOutput;
+		getEnvironment().setSourceOutputDirectory(new File(output));
+		JavaOutputProcessor fileOutput = new JavaOutputProcessor(new DefaultJavaPrettyPrinter(getEnvironment()));
 		fileOutput.setFactory(getFactory());
+
+		this.javaPrinter = fileOutput;
 	}
 
 	public void saveSourceCode(CtClass element) {


### PR DESCRIPTION
In Repairnator, as we are using several repair tools there is a conflict version with Spoon and astor is using Spoon 6.2.0 which is causing a NPE because of a change in the way we are using `JavaOutputProcessor`. 
This PR intends to upgrade to Spoon 6.2.0 and use the new constructor of `JavaOutputProcessor` in `OutputWritter` 