### PR TITLE
Check if JUnit process has terminated instead of catch IllegalThreadStateException

### DIFF
--- a/src/main/java/fr/inria/astor/core/validation/processbased/LaucherJUnitProcess.java
+++ b/src/main/java/fr/inria/astor/core/validation/processbased/LaucherJUnitProcess.java
@@ -23,9 +23,9 @@ import fr.inria.astor.core.validation.results.TestResult;
 
 /**
  * Lauches a process and parses its output.
- * 
+ *
  * @author Matias Martinez, matias.martinez@inria.fr
- * 
+ *
  */
 public class LaucherJUnitProcess {
 
@@ -116,7 +116,12 @@ public class LaucherJUnitProcess {
 			}
 
 			//
-			p.waitFor(waitTime, TimeUnit.MILLISECONDS);
+			if(!p.waitFor(waitTime, TimeUnit.MILLISECONDS)) {
+				p.destroyForcibly();
+				log.info("The Process that runs JUnit test cases did not terminate within waitTime");
+				log.info("Killed the Process that runs JUnit test cases");
+				return null;
+			}
 			long t_end = System.currentTimeMillis();
 			// log.debug("Execution time " + ((t_end - t_start) / 1000) + "
 			// seconds");
@@ -198,7 +203,7 @@ public class LaucherJUnitProcess {
 	 * This method analyze the output of the junit executor (i.e.,
 	 * {@link JUnitTestExecutor}) and return an entity called TestResult with
 	 * the result of the test execution
-	 * 
+	 *
 	 * @param p
 	 * @return
 	 */


### PR DESCRIPTION
[p.exitValue()](https://github.com/SpoonLabs/astor/blob/master/src/main/java/fr/inria/astor/core/validation/processbased/LaucherJUnitProcess.java#L126) will throw [IllegalThreadStateException](https://docs.oracle.com/javase/8/docs/api/java/lang/Process.html#exitValue--) if the process has not yet be terminated. This [try-catch](https://github.com/SpoonLabs/astor/blob/master/src/main/java/fr/inria/astor/core/validation/processbased/LaucherJUnitProcess.java#L137) block will catch that exception. However, I think the better approach here is to check the return value of [p.waitFor(waitTime, TimeUnit.MILLISECONDS)](https://docs.oracle.com/javase/8/docs/api/java/lang/Process.html#waitFor-long-java.util.concurrent.TimeUnit-) and force destroy it if necessary.