### PR TITLE
Simplify the usage of different modes

### DIFF
--- a/src/main/java/fr/inria/main/ExecutionMode.java
+++ b/src/main/java/fr/inria/main/ExecutionMode.java
@@ -1,10 +1,30 @@
 package fr.inria.main;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Execution modes included in Astor framework.
  * @author Matias Martinez matias.martinez@inria.fr
  *
  */
 public enum ExecutionMode {
-	DeepRepair, CARDUMEN, jGenProg, jKali, MutRepair, EXASTOR, custom
+	DeepRepair(Collections.singletonList("deeprepair")),
+	CARDUMEN(Collections.singletonList("cardumen")),
+	jGenProg(Collections.singletonList("jgenprog")),
+	jKali(Collections.singletonList("jkali")),
+	MutRepair(Arrays.asList("mutation","jmutrepair", "mutrepair")),
+	EXASTOR(Arrays.asList("exhaustive", "exastor")),
+	custom(Collections.singletonList("custom"));
+
+	private List<String> acceptedNames;
+
+	ExecutionMode(List<String> acceptedNames) {
+		this.acceptedNames = acceptedNames;
+	}
+
+	public List<String> getAcceptedNames() {
+		return acceptedNames;
+	}
 }

--- a/src/main/java/fr/inria/main/evolution/AstorMain.java
+++ b/src/main/java/fr/inria/main/evolution/AstorMain.java
@@ -168,23 +168,22 @@ public class AstorMain extends AbstractMain {
 
 		if (customEngine != null && !customEngine.isEmpty())
 			astorCore = createEngine(ExecutionMode.custom);
-		else if ("deeprepair".equals(mode))
-			astorCore = createEngine(ExecutionMode.DeepRepair);
-		else if ("cardumen".equals(mode))
-			astorCore = createEngine(ExecutionMode.CARDUMEN);
-		else if ("jgenprog".equals(mode))
-			astorCore = createEngine(ExecutionMode.jGenProg);
-		else if ("jkali".equals(mode))
-			astorCore = createEngine(ExecutionMode.jKali);
-		else if ("mutation".equals(mode) || "jmutrepair".equals(mode))
-			astorCore = createEngine(ExecutionMode.MutRepair);
-		else if ("exhaustive".equals(mode) || "exastor".equals(mode))
-			astorCore = createEngine(ExecutionMode.EXASTOR);
-
 		else {
-			System.err.println("Unknown mode of execution: '" + mode + "',  modes are: "
-					+ Arrays.toString(ExecutionMode.values()));
-			return;
+			for (ExecutionMode executionMode : ExecutionMode.values()) {
+				for (String acceptedName : executionMode.getAcceptedNames()) {
+					if (acceptedName.equals(mode)) {
+						astorCore = createEngine(executionMode);
+						break;
+					}
+				}
+			}
+
+			if (astorCore == null) {
+				System.err.println("Unknown mode of execution: '" + mode + "',  modes are: "
+						+ Arrays.toString(ExecutionMode.values()));
+				return;
+			}
+
 		}
 
 		ConfigurationProperties.print();


### PR DESCRIPTION
I just had an error when trying to use Astor because of this error message:
> Unknown mode of execution: 'mutrepair',  modes are: [DeepRepair, CARDUMEN, jGenProg, jKali, MutRepair, EXASTOR, custom]

So this PR is a proposal to improve the accepted names for the different modes.