### PR TITLE
reducing max time of validations to save execution time. Before the

### DIFF
--- a/src/main/resources/configuration.properties
+++ b/src/main/resources/configuration.properties
@@ -36,9 +36,9 @@ considerzerovaluesusp=false
 ##PopulationConformation
 reintroduce=PARENTS:ORIGINAL
 #Time for evaluation the failing test cases (in milliseconds):
-tmax1=120000
+tmax1=5000
 #Time for evaluation the test suite i.e., regression testing (in milliseconds):
-tmax2=960000
+tmax2=600000
 #
 stopfirst=false
 #


### PR DESCRIPTION
validation 1 was 2 minutes, now is 5 seconds. For val 2 is 10 minutes
instead of 16.