### PR TITLE
Fix Maven output coloring issue in getting-started.md (#146)

### DIFF
--- a/docs/getting-starting.md
+++ b/docs/getting-starting.md
@@ -27,7 +27,7 @@ Getting started:
      cd examples/Math-issue-280
      mvn clean compile test  # compiling and running bug example
      cd ../../
-     mvn dependency:build-classpath | egrep -v "(^\[INFO\]|^\[WARNING\])" | tee /tmp/astor-classpath.txt
+     mvn dependency:build-classpath -B | egrep -v "(^\[INFO\]|^\[WARNING\])" | tee /tmp/astor-classpath.txt
      cat /tmp/astor-classpath.txt
      
 Then the main command (note that the "location" argument is mandatory, and must be an absolute path):


### PR DESCRIPTION
On some machines, the final `astor-classpath.txt` had "weird encoding"
which made the egrep fail. This was caused by Maven trying to
[color the ouput](https://askubuntu.com/questions/983410/when-i-redirect-maven-commands-the-file-looks-wrongly-encoded) of the log. Adding -B parameter will fix this issue.

Related to gh-146