### PR TITLE
[bug fix] whitespace in classpath urls

### DIFF
--- a/src-3sfix/main/java/fr/inria/astor/approaches/_3sfix/FileProcessValidator.java
+++ b/src-3sfix/main/java/fr/inria/astor/approaches/_3sfix/FileProcessValidator.java
@@ -31,20 +31,8 @@ public class FileProcessValidator extends JUnitProcessValidator {
 	protected URL[] createClassPath(ProgramVariant mutatedVariant, ProjectRepairFacade projectFacade)
 			throws MalformedURLException {
 
-		URL[] defaultSUTClasspath = projectFacade
-				.getClassPathURLforProgramVariant(ProgramVariant.DEFAULT_ORIGINAL_VARIANT);
-		List<URL> originalURL = new ArrayList<>(Arrays.asList(defaultSUTClasspath));
-
-		String classpath = System.getProperty("java.class.path");
-
-		for (String path : classpath.split(File.pathSeparator)) {
-
-			File f = new File(path);
-			originalURL.add(new URL("file://" + f.getAbsolutePath()));
-
-		}
-
-		URL[] bc = null;
+		List<URL> originalURL = createOriginalURLs(projectFacade);
+		URL[] bc;
 
 		File variantOutputFile = defineLocationOfCompiledCode(mutatedVariant, projectFacade);
 

--- a/src/main/java/fr/inria/astor/core/validation/junit/JUnitProcessValidator.java
+++ b/src/main/java/fr/inria/astor/core/validation/junit/JUnitProcessValidator.java
@@ -108,20 +108,8 @@ public class JUnitProcessValidator extends ProgramVariantValidator {
 	protected URL[] createClassPath(ProgramVariant mutatedVariant, ProjectRepairFacade projectFacade)
 			throws MalformedURLException {
 
-		URL[] defaultSUTClasspath = projectFacade
-				.getClassPathURLforProgramVariant(ProgramVariant.DEFAULT_ORIGINAL_VARIANT);
-		List<URL> originalURL = new ArrayList<>(Arrays.asList(defaultSUTClasspath));
-
-		String classpath = System.getProperty("java.class.path");
-
-		for (String path : classpath.split(File.pathSeparator)) {
-
-			File f = new File(path);
-			originalURL.add(new URL("file://" + f.getAbsolutePath()));
-
-		}
-
-		URL[] bc = null;
+		List<URL> originalURL = createOriginalURLs(projectFacade);
+		URL[] bc;
 		if (mutatedVariant.getCompilation() != null) {
 
 			File variantOutputFile = defineLocationOfCompiledCode(mutatedVariant, projectFacade);
@@ -131,6 +119,23 @@ public class JUnitProcessValidator extends ProgramVariantValidator {
 			bc = originalURL.toArray(new URL[0]);
 		}
 		return bc;
+	}
+
+	public List<URL> createOriginalURLs(ProjectRepairFacade projectFacade) throws MalformedURLException {
+		URL[] defaultSUTClasspath = projectFacade
+				.getClassPathURLforProgramVariant(ProgramVariant.DEFAULT_ORIGINAL_VARIANT);
+		List<URL> originalURL = new ArrayList<>(Arrays.asList(defaultSUTClasspath));
+
+		String classpath = System.getProperty("java.class.path");
+
+		for (String path : classpath.split(File.pathSeparator)) {
+
+			File f = new File(path);
+			originalURL.add(new URL("file://\"" + f.getAbsolutePath() + "\""));
+
+		}
+
+		return originalURL;
 	}
 
 	protected File defineLocationOfCompiledCode(ProgramVariant mutatedVariant, ProjectRepairFacade projectFacade) {


### PR DESCRIPTION
I tried to run AstorMain on IntelliJ but got errors as the below logs:
```
/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/bin/java "-javaagent:/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar=61055:/Applications/IntelliJ IDEA.app/Contents/bin" -Dfile.encoding=UTF-8 -classpath /Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/charsets.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/deploy.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/ext/cldrdata.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/ext/dnsns.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/ext/jaccess.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/ext/jfxrt.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/ext/localedata.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/ext/nashorn.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/ext/sunec.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/ext/sunjce_provider.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/ext/sunpkcs11.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/ext/zipfs.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/javaws.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/jce.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/jfr.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/jfxswt.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/jsse.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/management-agent.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/plugin.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/resources.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre/lib/rt.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/lib/ant-javafx.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/lib/dt.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/lib/javafx-mx.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/lib/jconsole.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/lib/packager.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/lib/sa-jdi.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/lib/tools.jar:/Users/cuong/IdeaProjects/astor/target/classes:/Users/cuong/.m2/repository/log4j/log4j/1.2.17/log4j-1.2.17.jar:/Users/cuong/.m2/repository/fr/inria/gforge/spoon/spoon-core/7.5.0/spoon-core-7.5.0.jar:/Users/cuong/.m2/repository/org/eclipse/jdt/org.eclipse.jdt.core/3.16.0/org.eclipse.jdt.core-3.16.0.jar:/Users/cuong/.m2/repository/org/eclipse/platform/org.eclipse.core.resources/3.13.500/org.eclipse.core.resources-3.13.500.jar:/Users/cuong/.m2/repository/org/eclipse/platform/org.eclipse.core.expressions/3.6.500/org.eclipse.core.expressions-3.6.500.jar:/Users/cuong/.m2/repository/org/eclipse/platform/org.eclipse.core.runtime/3.16.0/org.eclipse.core.runtime-3.16.0.jar:/Users/cuong/.m2/repository/org/eclipse/platform/org.eclipse.osgi/3.15.0/org.eclipse.osgi-3.15.0.jar:/Users/cuong/.m2/repository/org/eclipse/platform/org.eclipse.equinox.common/3.10.500/org.eclipse.equinox.common-3.10.500.jar:/Users/cuong/.m2/repository/org/eclipse/platform/org.eclipse.core.jobs/3.10.500/org.eclipse.core.jobs-3.10.500.jar:/Users/cuong/.m2/repository/org/eclipse/platform/org.eclipse.equinox.registry/3.8.500/org.eclipse.equinox.registry-3.8.500.jar:/Users/cuong/.m2/repository/org/eclipse/platform/org.eclipse.equinox.preferences/3.7.500/org.eclipse.equinox.preferences-3.7.500.jar:/Users/cuong/.m2/repository/org/eclipse/platform/org.eclipse.core.contenttype/3.7.400/org.eclipse.core.contenttype-3.7.400.jar:/Users/cuong/.m2/repository/org/eclipse/platform/org.eclipse.equinox.app/1.4.300/org.eclipse.equinox.app-1.4.300.jar:/Users/cuong/.m2/repository/org/eclipse/platform/org.eclipse.core.filesystem/1.7.500/org.eclipse.core.filesystem-1.7.500.jar:/Users/cuong/.m2/repository/org/eclipse/platform/org.eclipse.text/3.9.0/org.eclipse.text-3.9.0.jar:/Users/cuong/.m2/repository/org/eclipse/platform/org.eclipse.core.commands/3.9.500/org.eclipse.core.commands-3.9.500.jar:/Users/cuong/.m2/repository/com/martiansoftware/jsap/2.1/jsap-2.1.jar:/Users/cuong/.m2/repository/org/apache/maven/maven-model/3.5.0/maven-model-3.5.0.jar:/Users/cuong/.m2/repository/org/codehaus/plexus/plexus-utils/3.0.24/plexus-utils-3.0.24.jar:/Users/cuong/.m2/repository/org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar:/Users/cuong/.m2/repository/org/tukaani/xz/1.8/xz-1.8.jar:/Users/cuong/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.9.9/jackson-databind-2.9.9.jar:/Users/cuong/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.9.0/jackson-annotations-2.9.0.jar:/Users/cuong/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.9.9/jackson-core-2.9.9.jar:/Users/cuong/.m2/repository/org/apache/commons/commons-compress/1.18/commons-compress-1.18.jar:/Users/cuong/.m2/repository/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar:/Users/cuong/.m2/repository/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar:/Users/cuong/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar:/Users/cuong/.m2/repository/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar:/Users/cuong/.m2/repository/commons-io/commons-io/2.5/commons-io-2.5.jar:/Users/cuong/.m2/repository/junit/junit/4.12/junit-4.12.jar:/Users/cuong/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar:/Users/cuong/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.1.0/junit-jupiter-engine-5.1.0.jar:/Users/cuong/.m2/repository/org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar:/Users/cuong/.m2/repository/org/junit/platform/junit-platform-engine/1.1.0/junit-platform-engine-1.1.0.jar:/Users/cuong/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.1.0/junit-jupiter-api-5.1.0.jar:/Users/cuong/.m2/repository/org/opentest4j/opentest4j/1.0.0/opentest4j-1.0.0.jar:/Users/cuong/.m2/repository/org/junit/platform/junit-platform-commons/1.1.0/junit-platform-commons-1.1.0.jar:/Users/cuong/.m2/repository/com/gzoltar/com.gzoltar.core/1.7.2/com.gzoltar.core-1.7.2.jar:/Users/cuong/.m2/repository/org/javassist/javassist/3.24.1-GA/javassist-3.24.1-GA.jar:/Users/cuong/.m2/repository/org/jacoco/org.jacoco.core/0.8.1/org.jacoco.core-0.8.1.jar:/Users/cuong/.m2/repository/org/ow2/asm/asm/6.0/asm-6.0.jar:/Users/cuong/.m2/repository/org/ow2/asm/asm-commons/6.0/asm-commons-6.0.jar:/Users/cuong/.m2/repository/org/ow2/asm/asm-tree/6.0/asm-tree-6.0.jar:/Users/cuong/.m2/repository/org/ow2/asm/asm-analysis/6.0/asm-analysis-6.0.jar:/Users/cuong/.m2/repository/org/ow2/asm/asm-util/6.0/asm-util-6.0.jar:/Users/cuong/.m2/repository/commons-cli/commons-cli/1.4/commons-cli-1.4.jar:/Users/cuong/.m2/repository/com/googlecode/json-simple/json-simple/1.1/json-simple-1.1.jar:/Users/cuong/.m2/repository/fil/iagl/cocospoon/CocoSpoon/1.0.0-SNAPSHOT/CocoSpoon-1.0.0-20190408.122227-1.jar:/Users/cuong/.m2/repository/org/easytesting/fest-assert/1.4/fest-assert-1.4.jar:/Users/cuong/.m2/repository/org/easytesting/fest-util/1.1.6/fest-util-1.1.6.jar:/Users/cuong/.m2/repository/fr/inria/gforge/spirals/nopol/0.2-SNAPSHOT/nopol-0.2-20180308.143049-1.jar:/Users/cuong/.m2/repository/org/reflections/reflections/0.9.9-RC1/reflections-0.9.9-RC1.jar:/Users/cuong/.m2/repository/dom4j/dom4j/1.6.1/dom4j-1.6.1.jar:/Users/cuong/.m2/repository/xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2.jar:/Users/cuong/.m2/repository/com/google/guava/guava/15.0/guava-15.0.jar:/Users/cuong/.m2/repository/ch/qos/logback/logback-classic/1.0.13/logback-classic-1.0.13.jar:/Users/cuong/.m2/repository/ch/qos/logback/logback-core/1.0.13/logback-core-1.0.13.jar:/Users/cuong/.m2/repository/org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.jar:/Users/cuong/.m2/repository/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar:/Users/cuong/.m2/repository/com/microsoft/z3/z3/0.0.1/z3-0.0.1.jar:/Users/cuong/.m2/repository/org/smtlib/smtlib/0.9.7.1/smtlib-0.9.7.1.jar:/Users/cuong/.m2/repository/sacha/infra/0.1/infra-0.1.jar:/Users/cuong/.m2/repository/com/gzoltar/gzoltar/0.1.1/gzoltar-0.1.1.jar:/Users/cuong/.m2/repository/com/cloudbees/diff4j/1.2/diff4j-1.2.jar:/Users/cuong/.m2/repository/org/jvnet/localizer/localizer/1.12/localizer-1.12.jar:/Users/cuong/.m2/repository/org/json/json/20160810/json-20160810.jar:/Users/cuong/.m2/repository/com/google/code/gson/gson/2.8.2/gson-2.8.2.jar fr.inria.main.evolution.AstorMain -location /tmp/math_70 -mode jGenProg -package org.apache.commons -failing org.apache.commons.math.analysis.solvers.BisectionSolverTest -srcjavafolder /src/java/ -srctestfolder /src/test/ -binjavafolder /target/classes -bintestfolder /target/test-classes -flthreshold 0.5 -stopfirst true
[INFO] 17:11:04,615 fr.inria.astor.core.setup.ProjectConfiguration:282 - Version of the JVM used: 1.8.0_201
[INFO] 17:11:04,616 main:380 - Java version of the JDK used to run tests: 1.8.0_201
[INFO] 17:11:04,616 main:381 - The compliance of the JVM is:  8
[INFO] 17:11:04,617 main:659 - command line arguments: [-location  /tmp/math_70  -mode  jGenProg  -package  org.apache.commons  -failing  org.apache.commons.math.analysis.solvers.BisectionSolverTest  -srcjavafolder  /src/java/  -srctestfolder  /src/test/  -binjavafolder  /target/classes  -bintestfolder  /target/test-classes  -flthreshold  0.5  -stopfirst  true]
[INFO] 17:11:04,653 fr.inria.main.evolution.AstorMain:212 - Running Astor on a JDK at /Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/jre
[INFO ] fr.inria.main.AbstractMain.determineSourceFolders(AbstractMain.java:973) - Source folders: [/tmp/math_70/src/main/java]
[INFO ] fr.inria.main.AbstractMain.determineSourceFolders(AbstractMain.java:992) - Source Test folders: [/tmp/math_70/src/test]
[INFO ] fr.inria.astor.core.solutionsearch.AstorCoreEngine.resolveTestsToRun(AstorCoreEngine.java:1311) - Test retrieved from classes: 238
[INFO ] fr.inria.astor.core.faultlocalization.gzoltar.GZoltarFaultLocalization.calculateSuspicious(GZoltarFaultLocalization.java:74) - -Executing Gzoltar classpath: /Users/cuong/IdeaProjects/astor/./output_astor/AstorMain-math_70//bin//default from 238 classes with test cases
[INFO ] fr.inria.astor.core.faultlocalization.gzoltar.GZoltarFaultLocalization.searchSuspicious(GZoltarFaultLocalization.java:154) - Gzoltar fault localization: min susp value parameter: 0.5
[INFO ] fr.inria.astor.core.faultlocalization.gzoltar.GZoltarFaultLocalization.searchSuspicious(GZoltarFaultLocalization.java:174) - -gz-Adding classpath: [/Users/cuong/IdeaProjects/astor/./output_astor/AstorMain-math_70//bin//default]
[INFO ] fr.inria.astor.core.faultlocalization.gzoltar.GZoltarFaultLocalization.searchSuspicious(GZoltarFaultLocalization.java:214) - Test failt: org.apache.commons.math.analysis.solvers.BisectionSolverTest#testMath369
[INFO ] fr.inria.astor.core.faultlocalization.gzoltar.GZoltarFaultLocalization.searchSuspicious(GZoltarFaultLocalization.java:226) - Gzoltar Test Result Total:2184, fails: 1, GZoltar suspicious 16642, with positive susp 14
[INFO ] fr.inria.astor.core.faultlocalization.gzoltar.GZoltarFaultLocalization.searchSuspicious(GZoltarFaultLocalization.java:234) - nr test results 2184
[INFO ] fr.inria.astor.core.faultlocalization.gzoltar.GZoltarFaultLocalization.searchSuspicious(GZoltarFaultLocalization.java:289) - Gzoltar found: 8 with susp > 0.5, we consider: 8
[INFO ] fr.inria.astor.core.solutionsearch.AstorCoreEngine.calculateSuspicious(AstorCoreEngine.java:898) - Setting up the max to 104030 milliseconds (104 sec)
[INFO ] fr.inria.astor.core.solutionsearch.AstorCoreEngine.initPopulation(AstorCoreEngine.java:709) - 
---- Creating spoon model
[INFO ] fr.inria.astor.core.manipulation.MutationSupporter.buildSpoonModel(MutationSupporter.java:236) - Creating model,  Code location from working folder: /tmp/math_70/src/main/java
[INFO ] fr.inria.astor.core.manipulation.MutationSupporter.buildModel(MutationSupporter.java:67) - building model: /tmp/math_70/src/main/java, compliance level: 8
[INFO ] fr.inria.astor.core.manipulation.MutationSupporter.buildModel(MutationSupporter.java:81) - Classpath (Dependencies) for building SpoonModel: null
[INFO ] fr.inria.astor.core.solutionsearch.AstorCoreEngine.initModel(AstorCoreEngine.java:779) - Number of CtTypes created: 416
[INFO ] fr.inria.astor.core.solutionsearch.AstorCoreEngine.initPopulation(AstorCoreEngine.java:713) - 
---- Initial suspicious size: 8
[INFO ] fr.inria.astor.core.solutionsearch.population.ProgramVariantFactory.createProgramInstance(ProgramVariantFactory.java:134) - Total suspicious from FL: 8,  8
[INFO ] fr.inria.astor.core.solutionsearch.population.ProgramVariantFactory.createProgramInstance(ProgramVariantFactory.java:143) - Total ModPoint created: 8
[INFO ] fr.inria.astor.core.solutionsearch.population.ProgramVariantFactory.createInitialPopulation(ProgramVariantFactory.java:82) - Creating program variant #1, [Variant id: 1, #gens: 8, #ops: 0, parent:-]
[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.solutionsearch.AstorCoreEngine.setFitnessOfPopulation(AstorCoreEngine.java:745) - Initial run of test suite fails
[INFO ] fr.inria.astor.core.solutionsearch.AstorCoreEngine.setFitnessOfPopulation(AstorCoreEngine.java:754) - The original fitness is : 1.7976931348623157E308
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:66) - ----------------------------
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:67) - ---Configuration properties:---Execution values
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:lastJUnitVersion= ./examples/libs/junit-4.11.jar
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:alternativecompliancelevel= 8
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:ignoredTestCases= 
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:workingDirectory= /Users/cuong/IdeaProjects/astor/./output_astor
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:manipulatesuper= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:validation= process
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:jvm4testexecution= /Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/bin
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:operatorspace= irr-statements
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:disablelog= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:binjavafolder= /target/classes
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:synthesis_depth= 3
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:gzoltartestpackagetoexclude= junit.framework
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:skipfitnessinitialpopulation= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:evosuiteresultfolder= evosuite
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:flthreshold= 0.5
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:regressionforfaultlocalization= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:collectonlyusedmethod= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:preservelinenumbers= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:tmax2= 104030
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:tmax1= 10000
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:probagenmutation= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:nomodificationconvergence= 100
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:diff_type= relative
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:targetelementprocessor= statements
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:srctestfolder= /src/test/
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:forceExecuteRegression= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:clusteringfilename= clustering.csv
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:failing= org.apache.commons.math.analysis.solvers.BisectionSolverTest
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:logtestexecution= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:evo_buggy_class= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:numberExecutions= 1
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:maxnumbersolutions= 1000000
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:evo_affected_by_op= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:population= 1
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:considerzerovaluesusp= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:maxCombinationVariableLimit= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:loglevel= INFO
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:savesolution= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:javacompliancelevel= 8
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:uniqueoptogen= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:gzoltarpackagetonotinstrument= junit.framework
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:projectIdentifier= 
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:modificationpointnavigation= weight
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:stopfirst= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:multipointmodification= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:elementsToMutate= 10
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:jsonoutputname= astor_output
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:evoDSE= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:bintestfolder= /target/test-classes
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:testbystep= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:version-location= ./math-version/
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:reintroduce= PARENTS:ORIGINAL
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:executorjar= ./lib/jtestex7.jar
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:maxGeneration= 200
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:max_synthesis_step= 10000
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:projectinfocommand= com.github.tdurieux:project-config-maven-plugin:info
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:maxVarCombination= 1000
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:maxtime= 60
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:evosuitejar= ./lib/evosuite-master-1.0.4-SNAPSHOT.jar
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:jvmversion= 1.8.0_201
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:commandTrunk= 50000
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:faultlocalization= gzoltar
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:resetmodel= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:maxsuspcandidates= 1000
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:mode= jGenProg
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:learningdir= 
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:jvm4evosuitetestexecution= /Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/bin
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:filterfaultlocalization= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:mutationrate= 1 
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:pathToMVNRepository= 
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:resourcesfolder= /src/main/resources:/src/test/resources:
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:timezone= America/Los_Angeles
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:runjava7code= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:evoRunOnBuggyClass= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:compiler= fr.inria.astor.core.manipulation.bytecode.compiler.SpoonClassCompiler
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:limitbysuspicious= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:logsattemps= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:logpatternlayout= [%-5p] %l - %m%n
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:packageToInstrument= org.apache.commons
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:skipfaultlocalization= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:scope= package
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:transformingredient= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:fitnessfunction= fr.inria.astor.core.solutionsearch.population.TestCaseFitnessFunction
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:maxnumvariablesperingredient= 10
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:parsesourcefromoriginal= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:pvariantfoldername= variant-
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:savespoonmodelondisk= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:srcjavafolder= /src/java/
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:populationcontroller= fr.inria.astor.core.solutionsearch.population.TestCaseBasedFitnessPopulationController
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:ignoreflakyinfl= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:cleantemplates= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:applyCrossover= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:maxmodificationpoints= 1000
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:duplicateingredientsinspace= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:metid= 0
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:continuewhenmodelfail= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:saveall= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:seed= 0
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:savecompletepatched= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:resetoperations= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:processoutputinfile= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:location= /tmp/math_70
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:probabilistictransformation= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:overridemaxtime= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:outputjsonresult= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:allpoints= false
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:bugId= 280
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:evosuitetimeout= 120
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:maxtimefactor= 10
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:nrPlaceholders= 1
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:69) - p:forcesubprocesskilling= true
[INFO ] fr.inria.astor.core.setup.ConfigurationProperties.print(ConfigurationProperties.java:71) - ----------------------------
[INFO ] fr.inria.astor.core.solutionsearch.EvolutionarySearchEngine.startEvolution(EvolutionarySearchEngine.java:40) - 
----Starting Solution Search
[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[ERROR] fr.inria.astor.core.validation.junit.LaucherJUnitProcess.getTestResult(LaucherJUnitProcess.java:294) - Error reading the validation process
 output: 
America/Los_Angeles
Error: Could not find or load main class IDEA.app.Contents.lib.idea_rt.jar:

[INFO ] fr.inria.astor.core.solutionsearch.AstorCoreEngine.atEnd(AstorCoreEngine.java:170) - Time Repair Loop (s): 20.543
[INFO ] fr.inria.astor.core.solutionsearch.AstorCoreEngine.atEnd(AstorCoreEngine.java:172) - generationsexecuted: 200
[INFO ] fr.inria.astor.core.solutionsearch.AstorCoreEngine.printFinalStatus(AstorCoreEngine.java:247) - 
----SUMMARY_EXECUTION---
[INFO ] fr.inria.astor.core.solutionsearch.AstorCoreEngine.printFinalStatus(AstorCoreEngine.java:257) - End Repair Search: NOT Found solution
[INFO ] fr.inria.main.evolution.AstorMain.run(AstorMain.java:196) - Time Total(s): 40.601

Process finished with exit code 0
```

I found that the error was caused by the whitespace character in a classpath from IntelliJ:
**/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar** (between **IntelliJ** and **IDEA.app**).

I avoided this error by adding double quotes for every classpath url.

I also extracted the duplicated code (after fixing the bug, between `src/main/java/fr/inria/astor/core/validation/junit/JUnitProcessValidator.java` and `src-3sfix/main/java/fr/inria/astor/approaches/_3sfix/FileProcessValidator.java`) into a new method to make source code more maintainable.

Regards,
Cuong Bui Quang