### PR TITLE
Fix GZoltar exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
 				<configuration>
 					<archive>
 						<manifest>
-							<mainClass>fully.qualified.MainClass</mainClass>
+							<mainClass>fr.inria.main.evolution.AstorMain</mainClass>
 						</manifest>
 					</archive>
 					<descriptorRefs>

--- a/src/main/java/fr/inria/astor/core/faultlocalization/gzoltar/GZoltarFaultLocalization.java
+++ b/src/main/java/fr/inria/astor/core/faultlocalization/gzoltar/GZoltarFaultLocalization.java
@@ -162,7 +162,7 @@ public class GZoltarFaultLocalization implements FaultLocalizationStrategy {
 		String projLocationPath = projLocationFile.getAbsolutePath();
 		logger.debug("Gzoltar run over: " + projLocationPath + " , does it exist? " + projLocationFile.exists());
 
-		GZoltar gz = new GZoltar(projLocationPath + File.separator);
+		GZoltar gz = new GZoltar(System.getProperty("user.dir") + File.separator);
 
 		// 2. Add Package/Class names to instrument
 		// 3. Add Package/Test Case/Test Suite names to execute

--- a/src/main/java/fr/inria/astor/core/validation/junit/JUnitProcessValidator.java
+++ b/src/main/java/fr/inria/astor/core/validation/junit/JUnitProcessValidator.java
@@ -118,6 +118,27 @@ public class JUnitProcessValidator extends ProgramVariantValidator {
 		} else {
 			bc = originalURL.toArray(new URL[0]);
 		}
+		
+		boolean isGZoltarDependencyFound = false;
+		
+		for (int i = 0; i < bc.length && !isGZoltarDependencyFound; i++) {
+			if (bc[i].getFile().contains("gzoltar-0.1.1")) {
+				isGZoltarDependencyFound = true;
+			}
+		}
+		
+		if (!isGZoltarDependencyFound) {
+			
+			URL[] newBc = new URL[bc.length + 1];
+			newBc[0] = new URL("file://\"" + "lib" + File.separator + "com.gzoltar-0.1.1-jar-with-dependencies.jar\"");
+			
+			for (int i = 0; i < bc.length; i++) {
+				newBc[i+1] = bc[i];
+			}
+			
+			return newBc;
+		}
+		
 		return bc;
 	}
 


### PR DESCRIPTION
These commits allow to avoid the exception `java.lang.IllegalArgumentException: No suspicious gen for analyze` when Astor is executed using its JAR version.

I changed also the value associated with the parameter `mainClass` in the pom.xml file, so that it is now possible to run Astor also without specifying the main class in this way:

`java -jar astor-jar-with-dependencies.jar -mode <>...`

