### PR TITLE
Disable `forcesubprocesskilling` as it is buggy.

### DIFF
--- a/src/main/resources/astor.properties
+++ b/src/main/resources/astor.properties
@@ -202,7 +202,7 @@ max_synthesis_step=10000
 #
 synthesis_depth=3
 #
-forcesubprocesskilling=true
+forcesubprocesskilling=false
 #
 collectonlyusedmethod=false
 #default|git|relative


### PR DESCRIPTION
The workarrond to kill the JUnit subprocesses implemented [here](https://github.com/SpoonLabs/astor/blob/7a148596edc683871d4fd97a82bebbf39f079240/src/main/java/fr/inria/astor/core/validation/junit/LaucherJUnitProcess.java#L184) kills the process with a `pid=pid+1` which could be a non-related process.