### PR TITLE
Cleaning of the workspace

### DIFF
--- a/src/main/java/fr/inria/astor/core/setup/ProjectRepairFacade.java
+++ b/src/main/java/fr/inria/astor/core/setup/ProjectRepairFacade.java
@@ -89,7 +89,7 @@ public class ProjectRepairFacade {
 	 *
 	 * @throws IOException
 	 */
-	public void cleanMutationResultSourceDirectories(String currentMutatorIdentifier) throws IOException {
+	public void cleanMutationResultSourceDirectory(String currentMutatorIdentifier) throws IOException {
 
 		removeDir(getProperties().getWorkingDirForSource() + File.separator + currentMutatorIdentifier, false);
 	}

--- a/src/main/java/fr/inria/astor/core/setup/ProjectRepairFacade.java
+++ b/src/main/java/fr/inria/astor/core/setup/ProjectRepairFacade.java
@@ -84,6 +84,16 @@ public class ProjectRepairFacade {
 		removeDir(getProperties().getWorkingDirForBytecode() + File.separator + currentMutatorIdentifier, false);
 	}
 
+	/**
+	 * Remove source dir for a given mutation
+	 *
+	 * @throws IOException
+	 */
+	public void cleanMutationResultSourceDirectories(String currentMutatorIdentifier) throws IOException {
+
+		removeDir(getProperties().getWorkingDirForSource() + File.separator + currentMutatorIdentifier, false);
+	}
+
 	public void cleanMutationResultDirectories() throws IOException {
 
 		removeDir(getProperties().getWorkingDirForSource(), true);

--- a/src/main/java/fr/inria/astor/core/setup/ProjectRepairFacade.java
+++ b/src/main/java/fr/inria/astor/core/setup/ProjectRepairFacade.java
@@ -80,24 +80,26 @@ public class ProjectRepairFacade {
 	 */
 	public void cleanMutationResultDirectories(String currentMutatorIdentifier) throws IOException {
 
-		removeDir(getProperties().getWorkingDirForSource() + File.separator + currentMutatorIdentifier);
-		removeDir(getProperties().getWorkingDirForBytecode() + File.separator + currentMutatorIdentifier);
+		removeDir(getProperties().getWorkingDirForSource() + File.separator + currentMutatorIdentifier, false);
+		removeDir(getProperties().getWorkingDirForBytecode() + File.separator + currentMutatorIdentifier, false);
 	}
 
 	public void cleanMutationResultDirectories() throws IOException {
 
-		removeDir(getProperties().getWorkingDirForSource());
-		removeDir(getProperties().getWorkingDirForBytecode());
+		removeDir(getProperties().getWorkingDirForSource(), true);
+		removeDir(getProperties().getWorkingDirForBytecode(), true);
 	}
 
-	private void removeDir(String dir) throws IOException {
+	private void removeDir(String dir, boolean isFolderToBeRecreated) throws IOException {
 		File dirin = new File(dir);
 		try {
 			FileUtils.deleteDirectory(dirin);
 		} catch (Exception ex) {
 			logger.error("ex: " + ex.getMessage());
 		}
-		dirin.mkdir();
+		if (isFolderToBeRecreated) {
+			dirin.mkdir();
+		}
 	}
 
 	public boolean copyOriginalBin(List<String> inDirs, String mutatorIdentifier) throws IOException {

--- a/src/main/java/fr/inria/astor/core/solutionsearch/AstorCoreEngine.java
+++ b/src/main/java/fr/inria/astor/core/solutionsearch/AstorCoreEngine.java
@@ -206,7 +206,14 @@ public abstract class AstorCoreEngine implements AstorExtensionPoint {
 					}
 				}
 			}
-
+			if (!ConfigurationProperties.getPropertyBool("saveall")) {
+				try {
+					projectFacade.cleanMutationResultDirectories(ProgramVariant.DEFAULT_ORIGINAL_VARIANT);
+				} catch (IOException e) {
+					e.printStackTrace();
+					log.error(e);
+				}
+			}
 		}
 
 	}
@@ -452,6 +459,9 @@ public abstract class AstorCoreEngine implements AstorExtensionPoint {
 				saveVariant(programVariant);
 
 				return true;
+			} else if (!ConfigurationProperties.getPropertyBool("saveall")) {
+				projectFacade.cleanMutationResultDirectories(
+						ConfigurationProperties.getProperty("pvariantfoldername") + programVariant.getId());
 			}
 		} else {
 			log.debug("-The child does NOT compile: " + programVariant.getId() + ", errors: "

--- a/src/main/java/fr/inria/astor/core/solutionsearch/AstorCoreEngine.java
+++ b/src/main/java/fr/inria/astor/core/solutionsearch/AstorCoreEngine.java
@@ -206,16 +206,16 @@ public abstract class AstorCoreEngine implements AstorExtensionPoint {
 					}
 				}
 			}
-			if (!ConfigurationProperties.getPropertyBool("saveall")) {
-				try {
-					projectFacade.cleanMutationResultDirectories(ProgramVariant.DEFAULT_ORIGINAL_VARIANT);
-				} catch (IOException e) {
-					e.printStackTrace();
-					log.error(e);
-				}
+		}
+		if (!ConfigurationProperties.getPropertyBool("saveall")) {
+			try {
+				projectFacade.cleanMutationResultDirectories(ProgramVariant.DEFAULT_ORIGINAL_VARIANT);
+				projectFacade.cleanMutationResultSourceDirectories(ProgramVariant.DEFAULT_ORIGINAL_VARIANT + PatchDiffCalculator.DIFF_SUFFIX);
+			} catch (IOException e) {
+				e.printStackTrace();
+				log.error(e);
 			}
 		}
-
 	}
 
 	protected void computePatchDiff(List<ProgramVariant> solutions) throws Exception {

--- a/src/main/java/fr/inria/astor/core/solutionsearch/AstorCoreEngine.java
+++ b/src/main/java/fr/inria/astor/core/solutionsearch/AstorCoreEngine.java
@@ -207,6 +207,15 @@ public abstract class AstorCoreEngine implements AstorExtensionPoint {
 				}
 			}
 		}
+		if (!ConfigurationProperties.getPropertyBool("saveall")) {
+ 			try {
+ 				projectFacade.cleanMutationResultDirectories(ProgramVariant.DEFAULT_ORIGINAL_VARIANT);
+ 				projectFacade.cleanMutationResultSourceDirectory(ProgramVariant.DEFAULT_ORIGINAL_VARIANT + PatchDiffCalculator.DIFF_SUFFIX);
+ 			} catch (IOException e) {
+ 				e.printStackTrace();
+ 				log.error(e);
+ 			}
+ 		}
 	}
 
 	protected void computePatchDiff(List<ProgramVariant> solutions) throws Exception {
@@ -450,9 +459,6 @@ public abstract class AstorCoreEngine implements AstorExtensionPoint {
 				saveVariant(programVariant);
 
 				return true;
-			} else if (!ConfigurationProperties.getPropertyBool("saveall")) {
-				projectFacade.cleanMutationResultDirectories(
-						ConfigurationProperties.getProperty("pvariantfoldername") + programVariant.getId());
 			}
 		} else {
 			log.debug("-The child does NOT compile: " + programVariant.getId() + ", errors: "

--- a/src/main/java/fr/inria/astor/core/solutionsearch/AstorCoreEngine.java
+++ b/src/main/java/fr/inria/astor/core/solutionsearch/AstorCoreEngine.java
@@ -207,15 +207,6 @@ public abstract class AstorCoreEngine implements AstorExtensionPoint {
 				}
 			}
 		}
-		if (!ConfigurationProperties.getPropertyBool("saveall")) {
- 			try {
- 				projectFacade.cleanMutationResultDirectories(ProgramVariant.DEFAULT_ORIGINAL_VARIANT);
- 				projectFacade.cleanMutationResultSourceDirectory(ProgramVariant.DEFAULT_ORIGINAL_VARIANT + PatchDiffCalculator.DIFF_SUFFIX);
- 			} catch (IOException e) {
- 				e.printStackTrace();
- 				log.error(e);
- 			}
- 		}
 	}
 
 	protected void computePatchDiff(List<ProgramVariant> solutions) throws Exception {

--- a/src/main/java/fr/inria/astor/core/solutionsearch/AstorCoreEngine.java
+++ b/src/main/java/fr/inria/astor/core/solutionsearch/AstorCoreEngine.java
@@ -207,6 +207,15 @@ public abstract class AstorCoreEngine implements AstorExtensionPoint {
 				}
 			}
 		}
+		if (!ConfigurationProperties.getPropertyBool("saveall")) {
+ 			try {
+ 				projectFacade.cleanMutationResultDirectories(ProgramVariant.DEFAULT_ORIGINAL_VARIANT);
+ 				projectFacade.cleanMutationResultSourceDirectory(ProgramVariant.DEFAULT_ORIGINAL_VARIANT + PatchDiffCalculator.DIFF_SUFFIX);
+ 			} catch (IOException e) {
+ 				e.printStackTrace();
+ 				log.error(e);
+ 			}
+ 		}
 	}
 
 	protected void computePatchDiff(List<ProgramVariant> solutions) throws Exception {
@@ -450,6 +459,9 @@ public abstract class AstorCoreEngine implements AstorExtensionPoint {
 				saveVariant(programVariant);
 
 				return true;
+			} else if (!ConfigurationProperties.getPropertyBool("saveall")) {
+				projectFacade.cleanMutationResultDirectories(
+						ConfigurationProperties.getProperty("pvariantfoldername") + programVariant.getId());
 			}
 		} else {
 			log.debug("-The child does NOT compile: " + programVariant.getId() + ", errors: "

--- a/src/main/java/fr/inria/astor/core/solutionsearch/AstorCoreEngine.java
+++ b/src/main/java/fr/inria/astor/core/solutionsearch/AstorCoreEngine.java
@@ -207,15 +207,6 @@ public abstract class AstorCoreEngine implements AstorExtensionPoint {
 				}
 			}
 		}
-		if (!ConfigurationProperties.getPropertyBool("saveall")) {
-			try {
-				projectFacade.cleanMutationResultDirectories(ProgramVariant.DEFAULT_ORIGINAL_VARIANT);
-				projectFacade.cleanMutationResultSourceDirectory(ProgramVariant.DEFAULT_ORIGINAL_VARIANT + PatchDiffCalculator.DIFF_SUFFIX);
-			} catch (IOException e) {
-				e.printStackTrace();
-				log.error(e);
-			}
-		}
 	}
 
 	protected void computePatchDiff(List<ProgramVariant> solutions) throws Exception {

--- a/src/main/java/fr/inria/astor/core/solutionsearch/AstorCoreEngine.java
+++ b/src/main/java/fr/inria/astor/core/solutionsearch/AstorCoreEngine.java
@@ -210,7 +210,7 @@ public abstract class AstorCoreEngine implements AstorExtensionPoint {
 		if (!ConfigurationProperties.getPropertyBool("saveall")) {
 			try {
 				projectFacade.cleanMutationResultDirectories(ProgramVariant.DEFAULT_ORIGINAL_VARIANT);
-				projectFacade.cleanMutationResultSourceDirectories(ProgramVariant.DEFAULT_ORIGINAL_VARIANT + PatchDiffCalculator.DIFF_SUFFIX);
+				projectFacade.cleanMutationResultSourceDirectory(ProgramVariant.DEFAULT_ORIGINAL_VARIANT + PatchDiffCalculator.DIFF_SUFFIX);
 			} catch (IOException e) {
 				e.printStackTrace();
 				log.error(e);


### PR DESCRIPTION
When the option "saveall" is not set, Astor now removes all the files in the bin folder (in the workspace) associated with the Program Variant folders that are not solutions, keeping clean the workspace and reducing the space used during the generation of the new variants. 

Astor removes also the original Program Variant folders in the workspace at the end of the process.